### PR TITLE
Fix build output sometimes being in program files directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,11 @@ set(CMAKE_CONFIGURATION_TYPES Debug Release RelWithDebInfo CACHE TYPE
 INTERNAL FORCE )
 
 project(NovusCore)
+
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set (CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/build" CACHE PATH "default install path" FORCE )
+endif()
+
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_INSTALL_PREFIX}")
 
@@ -38,10 +43,6 @@ add_compile_definitions($<CONFIG> NOMINMAX WIN32_LEAN_AND_MEAN)
 if (MSVC)
     add_definitions("/MP")
     add_compile_options("/WX")
-endif()
-
-if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set (CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/build" CACHE PATH "default install path" FORCE )
 endif()
 
 include(cmake/projectoptions.cmake)


### PR DESCRIPTION
What seems to have been the problem is that CMAKE_INSTALL_PREFIX is set and cached after CMAKE_RUNTIME_OUTPUT_DIRECTORY is set which would lead to it trying to put build output in the default CMAKE_INSTALL_PREFIX instead of the intended one.

What I did was simply move setting the CMAKE_INSTALL_PREFIX to before setting the CMAKE_RUNTIME_OUTPUT_DIRECTORY which should prevent the problem from happening. 

In my tests the problem hasn't appeared come up again after this change. Before the change it seemed to constantly come up.