### PR TITLE
Fix ByteBufffer.h missing <string> in VS2019

### DIFF
--- a/projects/common/Networking/ByteBuffer.h
+++ b/projects/common/Networking/ByteBuffer.h
@@ -26,6 +26,7 @@
 #include "../NovusTypes.h"
 #include <vector>
 #include <cassert>
+#include <string>
 
 namespace Common
 {


### PR DESCRIPTION
Fixes a missing include in ByteBuffer.h that only raises problems in VS2019.