### PR TITLE
Console Window Titles for Windows.

### DIFF
--- a/projects/authserver/main.cpp
+++ b/projects/authserver/main.cpp
@@ -29,10 +29,19 @@
 #include "ConnectionHandlers/ClientAuthConnectionHandler.h"
 #include "ConnectionHandlers/RelayNodeConnectionHandler.h"
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
+//The name of the console window.
+#define WINDOWNAME "Authentication Server"
+
 i32 main()
 {
-    /* Initialize Debug Handler */
-    //InitDebugger(PROGRAM_TYPE::Char);
+	/* Set up console window title */
+#ifdef _WIN32  //Windows
+	SetConsoleTitle(WINDOWNAME);
+#endif
 
     /* Load Database Config Handler for server */
     if (!ConfigHandler::Load("database_configuration.json"))

--- a/projects/characterserver/main.cpp
+++ b/projects/characterserver/main.cpp
@@ -29,10 +29,19 @@
 #include "Connections\NovusConnection.h"
 #include "../DatabaseCache/CharacterDatabaseCache.h"
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
+//The name of the console window.
+#define WINDOWNAME "Character Server"
+
 i32 main()
 {
-    /* Initialize Debug Handler */
-    //InitDebugger(PROGRAM_TYPE::Char);
+	/* Set up console window title */
+#ifdef _WIN32  //Windows
+	SetConsoleTitle(WINDOWNAME);
+#endif
 
     /* Load Database Config Handler for server */
     if (!ConfigHandler::Load("database_configuration.json"))

--- a/projects/relayserver/main.cpp
+++ b/projects/relayserver/main.cpp
@@ -31,12 +31,22 @@
 #include "ConnectionHandlers\ClientRelayConnectionHandler.h"
 #include "ConnectionHandlers\NovusConnectionHandler.h"
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 NovusConnectionHandler*         NovusConnectionHandler::_instance       = nullptr;
 ClientRelayConnectionHandler*   ClientRelayConnectionHandler::_instance = nullptr;
+
+//The name of the console window.
+#define WINDOWNAME "Relay Server"
+
 i32 main()
 {
-    /* Initialize Debug Handler */
-    //InitDebugger(PROGRAM_TYPE::Relay);
+	/* Set up console window title */
+#ifdef _WIN32  //Windows
+	SetConsoleTitle(WINDOWNAME);
+#endif
 
     /* Load Database Config Handler for server */
     if (!ConfigHandler::Load("database_configuration.json"))

--- a/projects/worldserver/main.cpp
+++ b/projects/worldserver/main.cpp
@@ -14,6 +14,10 @@
 
 #include "ConsoleCommands.h"
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 std::string GetLineFromCin() 
 {
 	std::string line;
@@ -21,9 +25,15 @@ std::string GetLineFromCin()
 	return line;
 }
 
+//The name of the console window.
+#define WINDOWNAME "World Server"
+
 i32 main()
 {
-    //InitDebugger(PROGRAM_TYPE::World);
+	/* Set up console window title */
+#ifdef _WIN32  //Windows
+	SetConsoleTitle(WINDOWNAME);
+#endif
 
     /* Load Database Config Handler for server */
     if (!ConfigHandler::Load("database_configuration.json"))


### PR DESCRIPTION
Each server window now says what server it is now making it atleast 1% easier to see which server each windows is for at a glance *on windows atleast.*

Also removed the InitDebugger statements as by request of Nixify