### PR TITLE
[CMake] Use modern CMake features for `common` and its dependencies

### DIFF
--- a/dep/TracyProfiler/CMakeLists.txt
+++ b/dep/TracyProfiler/CMakeLists.txt
@@ -20,4 +20,26 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+project(tracy VERSION 1.0.0)
+
 set(ENABLE_TRACY_PROFILER false CACHE BOOL "Enables Tracy profiling")
+
+add_library(${PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+set(TRACY_SOURCE
+    "${CMAKE_CURRENT_LIST_DIR}/tracy/TracyClient.cpp"
+)
+
+source_group(TracyProfiler ${TRACY_SOURCE})
+
+target_sources(${PROJECT_NAME} INTERFACE
+    ${TRACY_SOURCE}
+)
+
+if (ENABLE_TRACY_PROFILER)
+    target_compile_definitions(${PROJECT_NAME} INTERFACE
+        TRACY_ENABLE
+        TRACY_ON_DEMAND
+    )
+endif()

--- a/dep/openssl/CMakeLists.txt
+++ b/dep/openssl/CMakeLists.txt
@@ -22,12 +22,14 @@
 
 set(OPENSSL_EXPECTED_VERSION 1.0.0)
 
-if (UNIX)
+if (NOT DEFINED OPENSSL_ROOT_DIR AND (UNIX OR APPLE))
   set (OPENSSL_ROOT_DIR "/usr/local/opt/openssl" CACHE PATH "default install path" FORCE )
-endif(UNIX)
+endif()
 
 find_package(OpenSSL REQUIRED)
+
 add_library(openssl INTERFACE)
+add_library(openssl::openssl ALIAS openssl)
 
 target_link_libraries(openssl
   INTERFACE

--- a/dep/zlib/CMakeLists.txt
+++ b/dep/zlib/CMakeLists.txt
@@ -60,3 +60,5 @@ else()
         FOLDER
           "dep")
 endif()
+
+add_library(zlib::zlib ALIAS zlib)

--- a/projects/common/CMakeLists.txt
+++ b/projects/common/CMakeLists.txt
@@ -23,27 +23,23 @@
 project(common VERSION 1.0.0 DESCRIPTION "Common is a static library for NovusCore")
 
 file(GLOB_RECURSE COMMON_FILES "*.cpp" "*.h")
-set(COMMON_DEPENDENCIES
-    "${CMAKE_CURRENT_LIST_DIR}/Dependencies/amy"
-    "${CMAKE_CURRENT_LIST_DIR}/Dependencies/json"
-    "${CMAKE_CURRENT_LIST_DIR}/Dependencies/robin-hood-hashing"
-    "${CMAKE_SOURCE_DIR}/dep/asio"
-)
-set(TRACY
-    "${CMAKE_SOURCE_DIR}/dep/TracyProfiler/tracy/TracyClient.cpp"
-)
 
-add_library(common ${COMMON_FILES} ${TRACY})
+add_subdirectory(Dependencies)
+
+add_library(common ${COMMON_FILES})
+add_library(common::common ALIAS common)
+
 find_assign_files(${COMMON_FILES})
-source_group(TracyProfiler ${TRACY})
 
 target_include_directories(common PRIVATE ${COMMON_DEPENDENCIES})
-target_link_libraries(common asio openssl mysql zlib)
+target_link_libraries(common PUBLIC
+    tracy::tracy
+    common::dependencies
+    openssl::openssl
+    zlib::zlib
+)
 
 add_compile_definitions(NOMINMAX _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS)
-if (ENABLE_TRACY_PROFILER)
-add_compile_definitions(TRACY_ENABLE TRACY_ON_DEMAND)
-endif()
 
 # Set VERSION & FOLDER Property
 set_target_properties(common PROPERTIES VERSION ${PROJECT_VERSION})

--- a/projects/common/Dependencies/CMakeLists.txt
+++ b/projects/common/Dependencies/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 
-# Copyright (c) 2018 NovusCore
+# Copyright (c) 2018-2019 NovusCore
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,16 +20,50 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-project(asio VERSION 1.0.0)
+project(common_deps VERSION 1.0.0)
+
+## Amy
+
+find_package(MySQL REQUIRED)
+
+add_library(amy INTERFACE)
+add_library(amy::amy ALIAS amy)
+
+target_include_directories(amy INTERFACE
+    "${CMAKE_CURRENT_LIST_DIR}/amy"
+)
+
+target_link_libraries(amy INTERFACE
+    MySQL::MySQL
+    asio::asio
+)
+
+## Json
+
+add_library(json INTERFACE)
+add_library(json::json ALIAS json)
+
+target_include_directories(json INTERFACE
+    "${CMAKE_CURRENT_LIST_DIR}/json"
+)
+
+## Robin hood hashing
+
+add_library(robin-hood-hashing INTERFACE)
+add_library(robin-hood-hashing::robin-hood-hashing ALIAS robin-hood-hashing)
+
+target_include_directories(robin-hood-hashing INTERFACE
+    "${CMAKE_CURRENT_LIST_DIR}/robin-hood-hashing"
+)
+
+## common_deps
 
 add_library(${PROJECT_NAME} INTERFACE)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+add_library(common::dependencies ALIAS ${PROJECT_NAME})
 
-find_package(Threads)
-
-target_include_directories(${PROJECT_NAME} INTERFACE "${CMAKE_CURRENT_LIST_DIR}")
-target_link_libraries(${PROJECT_NAME} INTERFACE "${CMAKE_THREAD_LIBS_INIT}")
-target_compile_definitions(${PROJECT_NAME} INTERFACE
-    ASIO_STANDALONE
-    ASIO_HAS_STD_CHRONO
+target_link_libraries(${PROJECT_NAME} INTERFACE
+    amy::amy
+    json::json
+    robin-hood-hashing::robin-hood-hashing
 )


### PR DESCRIPTION
Affected subprojects:
- asio
- common - amy
- common - json
- common - robin-hood-hashing
- openssl
- tracy
- zlib