### PR TITLE
[General] Fix worldnode and tools build for macos

### DIFF
--- a/projects/tools/dataextractor/CMakeLists.txt
+++ b/projects/tools/dataextractor/CMakeLists.txt
@@ -29,7 +29,9 @@ find_assign_files(${DATAEXTRACTOR_FILES})
 
 set_property(TARGET dataextractor PROPERTY CXX_STANDARD 17)
 
-if (UNIX)
+if(APPLE)
+    target_link_libraries(dataextractor c++fs)
+elseif (UNIX)
     target_link_libraries(dataextractor stdc++fs)
 endif()
 

--- a/projects/worldnode/CMakeLists.txt
+++ b/projects/worldnode/CMakeLists.txt
@@ -39,7 +39,9 @@ find_assign_files(${WORLDNODE_FILES})
 
 set_property(TARGET worldnode PROPERTY CXX_STANDARD 17)
 
-if (UNIX)
+if (APPLE)
+    target_link_libraries(worldnode c++fs)
+elseif (UNIX)
     target_link_libraries(worldnode stdc++fs)
 endif()
 


### PR DESCRIPTION
The WorldNode and data extrator in tools use std::filesystem which is
not available by default in llvm 8, which is the latest version of llvm
that you can get via homebrew.

There was a fix in place but that compiler flag only seems to work in linux.

This patch allows us to compile projects that use std::filesystem under
linux and macos.