### PR TITLE
Fix clang compiler warning on macos

### DIFF
--- a/dep/libmpq/libmpq/explode.c
+++ b/dep/libmpq/libmpq/explode.c
@@ -32,6 +32,8 @@
 /* libmpq generic includes. */
 #include "explode.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
 /* tables used for data extraction. */
 static const uint8_t pkzip_dist_bits[] = {
 	0x02, 0x04, 0x04, 0x05, 0x05, 0x05, 0x05, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06,
@@ -600,3 +602,4 @@ uint32_t libmpq__do_decompress_pkzip(uint8_t *work_buf, void *param) {
 	/* something failed, so return error. */
 	return LIBMPQ_PKZIP_CMP_ABORT;
 }
+#pragma GCC diagnostic pop

--- a/projects/common/Utils/DebugHandler.h
+++ b/projects/common/Utils/DebugHandler.h
@@ -64,6 +64,8 @@ DebugHandler::PrintFatal(message, ##__VA_ARGS__);
 #define NC_LOG_SUCCESS(message, ...) if (!DebugHandler::isInitialized) { DebugHandler::Initialize(); } \
 DebugHandler::PrintSuccess(message, ##__VA_ARGS__);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
 class DebugHandler
 {
 public:
@@ -145,7 +147,7 @@ private:
                 withColors = message;
         }
 
-        printf(withColors.c_str(), args...);
+        Print(withColors, args...);
 #endif
     }
 
@@ -154,3 +156,4 @@ private:
     static HANDLE _handle;
 #endif
 };
+#pragma GCC diagnostic pop

--- a/projects/realmserver/Connections/RealmConnection.cpp
+++ b/projects/realmserver/Connections/RealmConnection.cpp
@@ -218,7 +218,7 @@ bool RealmConnection::HandleHeaderRead()
     // Reverse size bytes
     EndianConvertReverse(header->size);
 
-    if (header->size < 4 && header->size > 10240 || header->command >= Common::Opcode::NUM_MSG_TYPES)
+    if ((header->size < 4 && header->size > 10240) || header->command >= Common::Opcode::NUM_MSG_TYPES)
     {
         std::cout << "header->size < 4: " << (header->size < 4) << ", header->size > 10240: " << (header->size > 10240) << ", header->command >= Common::Opcode::NUM_MSG_TYPES: " << (header->command >= Common::Opcode::NUM_MSG_TYPES) << std::endl;
         return false;

--- a/projects/worldnode/Connections/WorldConnection.cpp
+++ b/projects/worldnode/Connections/WorldConnection.cpp
@@ -218,7 +218,7 @@ bool WorldConnection::HandleHeaderRead()
     // Reverse size bytes
     EndianConvertReverse(header->size);
 
-    if (header->size < 4 && header->size > 10240 || header->command >= Common::Opcode::NUM_MSG_TYPES)
+    if ((header->size < 4 && header->size > 10240) || header->command >= Common::Opcode::NUM_MSG_TYPES)
     {
         std::cout << "header->size < 4: " << (header->size < 4) << ", header->size > 10240: " << (header->size > 10240) << ", header->command >= Common::Opcode::NUM_MSG_TYPES: " << (header->command >= Common::Opcode::NUM_MSG_TYPES) << std::endl;
         return false;

--- a/projects/worldnode/Game/ObjectGuid/ObjectGuid.h
+++ b/projects/worldnode/Game/ObjectGuid/ObjectGuid.h
@@ -41,11 +41,11 @@ public:
 			case HighGuid::Pet:
 			case HighGuid::Vehicle:
 				return true;
+            default:
+                return false;
 		}
-
-		return false;
 	}
-	
+
 	bool IsPlayer() const { return GetHighType() == HighGuid::Player; }
 	bool IsItem() const { return GetHighType() == HighGuid::Item; }
 	bool IsUnit() const { return GetHighType() == HighGuid::Unit; }

--- a/projects/worldnode/Utils/UpdateData.h
+++ b/projects/worldnode/Utils/UpdateData.h
@@ -23,7 +23,7 @@ public:
 
     bool Build(Common::ByteBuffer& packet, u16& opcode)
     {
-        Common::ByteBuffer buffer((4 + _nonVisibleGuids.empty() ? 0 : 1 + 4 + 9 * _nonVisibleGuids.size()) + _data._writePos);
+        Common::ByteBuffer buffer;
         buffer.Write<u32>(_nonVisibleGuids.empty() ? _blockCount : _blockCount + 1);
 
         if (!_nonVisibleGuids.empty())


### PR DESCRIPTION
This fixes almost all of the compiler warnings on clang for macos.
The only warning I can't seem to get rid of is this one:

```sh
[  6%] Building C object dep/libmpq/CMakeFiles/mpq.dir/libmpq/extract.c.o
clang-8: warning: argument unused during compilation: '-L/usr/local/lib' [-Wunused-command-line-argument]
[  8%] Building C object dep/libmpq/CMakeFiles/mpq.dir/libmpq/huffman.c.o
clang-8: warning: argument unused during compilation: '-L/usr/local/lib' [-Wunused-command-line-argument]
[ 10%] Building C object dep/libmpq/CMakeFiles/mpq.dir/libmpq/mpq.c.o
clang-8: warning: argument unused during compilation: '-L/usr/local/lib' [-Wunused-command-line-argument]
[ 12%] Building C object dep/libmpq/CMakeFiles/mpq.dir/libmpq/wave.c.o
clang-8: warning: argument unused during compilation: '-L/usr/local/lib' [-Wunused-command-line-argument]
```

Any suggestions would be appreciated.