### PR TITLE
DataStore Implementation

### DIFF
--- a/projects/authserver/Connections/AuthConnection.cpp
+++ b/projects/authserver/Connections/AuthConnection.cpp
@@ -46,40 +46,6 @@ struct cAuthLogonChallenge
     u8   username_pointer[1];
 };
 
-struct sAuthLogonChallengeHeader
-{
-    u8  command;
-    u8  error;
-    u8  result;
-
-    void AddTo(Common::ByteBuffer& buffer)
-    {
-        buffer.Append(reinterpret_cast<u8*>(this), sizeof(sAuthLogonChallengeHeader));
-    }
-};
-
-struct sAuthLogonChallengeData
-{
-    u8 b[32];
-    u8 g_length;
-    u8 g;
-    u8 n_length;
-    u8 n[32];
-    u8 salt[32];
-    u8 version_challenge[16];
-    u8 security_flags;
-
-    void AddTo(Common::ByteBuffer& buffer)
-    {
-        buffer.Append(reinterpret_cast<u8*>(this), sizeof(sAuthLogonChallengeData));
-    }
-
-    void Append(u8* dest, const u8* src, size_t size)
-    {
-        std::memcpy(dest, src, size);
-    }
-};
-
 struct cAuthLogonProof
 {
     u8   command;
@@ -238,12 +204,6 @@ bool AuthConnection::HandleCommandChallenge()
 }
 void AuthConnection::HandleCommandChallengeCallback(amy::result_set& results)
 {
-    Common::ByteBuffer response;
-
-    sAuthLogonChallengeHeader header;
-    header.command = AUTH_CHALLENGE;
-    header.error = 0;
-
     DataStore dataStore;
     dataStore.PutU8(AUTH_CHALLENGE);
     dataStore.PutU8(0);

--- a/projects/authserver/Connections/AuthConnection.cpp
+++ b/projects/authserver/Connections/AuthConnection.cpp
@@ -109,11 +109,11 @@ robin_hood::unordered_map<u8, AuthMessageHandler> AuthConnection::InitMessageHan
 {
     robin_hood::unordered_map<u8, AuthMessageHandler> messageHandlers;
 
-    messageHandlers[AUTH_CHALLENGE]             = { STATUS_CHALLENGE,         4,                              1,   &AuthConnection::HandleCommandChallenge          };
-    messageHandlers[AUTH_PROOF]                 = { STATUS_PROOF,             sizeof(cAuthLogonProof),        1,   &AuthConnection::HandleCommandProof              };
-    messageHandlers[AUTH_RECONNECT_CHALLENGE]   = { STATUS_CHALLENGE,         4,                              1,   &AuthConnection::HandleCommandReconnectChallenge };
-    messageHandlers[AUTH_RECONNECT_PROOF]       = { STATUS_RECONNECT_PROOF,   sizeof(cAuthReconnectProof),    1,   &AuthConnection::HandleCommandReconnectProof     };
-    messageHandlers[AUTH_GAMESERVER_LIST]       = { STATUS_AUTHED,            5,                              3,   &AuthConnection::HandleCommandGameServerList     };
+    messageHandlers[AUTH_CHALLENGE] = { STATUS_CHALLENGE,         4,                              1,   &AuthConnection::HandleCommandChallenge };
+    messageHandlers[AUTH_PROOF] = { STATUS_PROOF,             sizeof(cAuthLogonProof),        1,   &AuthConnection::HandleCommandProof };
+    messageHandlers[AUTH_RECONNECT_CHALLENGE] = { STATUS_CHALLENGE,         4,                              1,   &AuthConnection::HandleCommandReconnectChallenge };
+    messageHandlers[AUTH_RECONNECT_PROOF] = { STATUS_RECONNECT_PROOF,   sizeof(cAuthReconnectProof),    1,   &AuthConnection::HandleCommandReconnectProof };
+    messageHandlers[AUTH_GAMESERVER_LIST] = { STATUS_AUTHED,            5,                              3,   &AuthConnection::HandleCommandGameServerList };
 
     return messageHandlers;
 }
@@ -198,7 +198,7 @@ bool AuthConnection::HandleCommandChallenge()
 
     PreparedStatement stmt("SELECT guid, salt, verifier FROM accounts WHERE username={s};");
     stmt.Bind(username);
-    DatabaseConnector::QueryAsync(DATABASE_TYPE::AUTHSERVER, stmt, [this](amy::result_set& results, DatabaseConnector& connector) { HandleCommandChallengeCallback(results); });
+    DatabaseConnector::QueryAsync(DATABASE_TYPE::AUTHSERVER, stmt, [this](amy::result_set & results, DatabaseConnector & connector) { HandleCommandChallengeCallback(results); });
 
     return true;
 }
@@ -238,6 +238,19 @@ void AuthConnection::HandleCommandChallengeCallback(amy::result_set& results)
     _status = STATUS_PROOF;
     dataStore.PutU8(AUTH_SUCCESS);
 
+
+    /* Logon Challenge Data Structure
+
+       - Type: u8[32],  Name: B
+       - Type: u8,      Name: Lenght of G
+       - Type: u8,      Name: G
+       - Type: u8,      Name: Lenght of N
+       - Type: u8[32],  Name: N
+       - Type: u8[32],  Name: Salt
+       - Type: u8[16],  Name: Version Challenge
+       - Type: u8,      Name: Security Flag
+       https://en.wikipedia.org/wiki/Secure_Remote_Password_protocol
+    */
     dataStore.PutBytes(B.BN2BinArray(32).get(), 32);
     dataStore.PutU8(1);
     dataStore.PutU8(g.BN2BinArray(32).get()[0]);
@@ -345,25 +358,25 @@ bool AuthConnection::HandleCommandProof()
         PreparedStatement stmt("UPDATE accounts SET sessionkey={s} WHERE username={s};");
         stmt.Bind(K.BN2Hex());
         stmt.Bind(username);
-        DatabaseConnector::QueryAsync(DATABASE_TYPE::AUTHSERVER, stmt, [this, proofM2](amy::result_set& results, DatabaseConnector& connector)
-        {
-            Common::ByteBuffer packet;
-            sAuthLogonProof proof;
+        DatabaseConnector::QueryAsync(DATABASE_TYPE::AUTHSERVER, stmt, [this, proofM2](amy::result_set & results, DatabaseConnector & connector)
+            {
+                Common::ByteBuffer packet;
+                sAuthLogonProof proof;
 
-            memcpy(proof.M2, proofM2, 20);
-            proof.cmd = AUTH_PROOF;
-            proof.error = 0;
-            proof.AccountFlags = 0x00;    // 0x01 = GM, 0x08 = Trial, 0x00800000 = Pro pass (arena tournament)
-            proof.SurveyId = 0;
-            proof.LoginFlags = 0x00;
+                memcpy(proof.M2, proofM2, 20);
+                proof.cmd = AUTH_PROOF;
+                proof.error = 0;
+                proof.AccountFlags = 0x00;    // 0x01 = GM, 0x08 = Trial, 0x00800000 = Pro pass (arena tournament)
+                proof.SurveyId = 0;
+                proof.LoginFlags = 0x00;
 
-            packet.Resize(sizeof(proof));
-            std::memcpy(packet.data(), &proof, sizeof(proof));
-            packet.WriteBytes(sizeof(proof));
+                packet.Resize(sizeof(proof));
+                std::memcpy(packet.data(), &proof, sizeof(proof));
+                packet.WriteBytes(sizeof(proof));
 
-            Send(packet);
-            _status = STATUS_AUTHED;
-        });
+                Send(packet);
+                _status = STATUS_AUTHED;
+            });
     }
     else
     {
@@ -439,61 +452,61 @@ bool AuthConnection::HandleCommandGameServerList()
 {
     _status = STATUS_WAITING_FOR_GAMESERVER;
 
-    DatabaseConnector::QueryAsync(DATABASE_TYPE::AUTHSERVER, "SELECT id, name, address, type, flags, timezone, population FROM realms;", [this](amy::result_set& results, DatabaseConnector& connector)
-    {
-        std::vector<u8> realmCharacterData(MAX_REALM_COUNT);
-        std::fill(realmCharacterData.begin(), realmCharacterData.end(), 0);
-
-        std::shared_ptr<DatabaseConnector> borrowedConnector;
-        DatabaseConnector::Borrow(DATABASE_TYPE::AUTHSERVER, borrowedConnector);
-        amy::result_set realmCharacterCountResult;
-
-        PreparedStatement realmCharacterCount("SELECT realmid, characters FROM realm_characters WHERE account={u};");
-        realmCharacterCount.Bind(accountGuid);
-        if (borrowedConnector->Query(realmCharacterCount, realmCharacterCountResult))
+    DatabaseConnector::QueryAsync(DATABASE_TYPE::AUTHSERVER, "SELECT id, name, address, type, flags, timezone, population FROM realms;", [this](amy::result_set & results, DatabaseConnector & connector)
         {
-            for (auto row : realmCharacterCountResult)
+            std::vector<u8> realmCharacterData(MAX_REALM_COUNT);
+            std::fill(realmCharacterData.begin(), realmCharacterData.end(), 0);
+
+            std::shared_ptr<DatabaseConnector> borrowedConnector;
+            DatabaseConnector::Borrow(DATABASE_TYPE::AUTHSERVER, borrowedConnector);
+            amy::result_set realmCharacterCountResult;
+
+            PreparedStatement realmCharacterCount("SELECT realmid, characters FROM realm_characters WHERE account={u};");
+            realmCharacterCount.Bind(accountGuid);
+            if (borrowedConnector->Query(realmCharacterCount, realmCharacterCountResult))
             {
-                realmCharacterData[row[0].GetU8()] = row[1].GetU8();
+                for (auto row : realmCharacterCountResult)
+                {
+                    realmCharacterData[row[0].GetU8()] = row[1].GetU8();
+                }
             }
-        }
 
-        Common::ByteBuffer realmBuffer;
-        for (auto row : results)
-        {
-            sAuthLogonGameListData realmData;
-            realmData.Id = row[0].GetU8();
-            realmData.Name = row[1].GetString();
-            realmData.Address = row[2].GetString();
-            realmData.Type = row[3].GetU8();
-            realmData.Flags = row[4].GetU8();
-            realmData.Timezone = row[5].GetU8();
-            realmData.Population = row[6].GetF32();
-            realmData.Characters = realmCharacterData[realmData.Id];
-            realmData.Locked = 0;
+            Common::ByteBuffer realmBuffer;
+            for (auto row : results)
+            {
+                sAuthLogonGameListData realmData;
+                realmData.Id = row[0].GetU8();
+                realmData.Name = row[1].GetString();
+                realmData.Address = row[2].GetString();
+                realmData.Type = row[3].GetU8();
+                realmData.Flags = row[4].GetU8();
+                realmData.Timezone = row[5].GetU8();
+                realmData.Population = row[6].GetF32();
+                realmData.Characters = realmCharacterData[realmData.Id];
+                realmData.Locked = 0;
 
-            realmData.AddTo(realmBuffer);
-        }
+                realmData.AddTo(realmBuffer);
+            }
 
-        // (Only needed for clients TBC+)
-        realmBuffer.Write<u8>(0x10); // Unk1
-        realmBuffer.Write<u8>(0x00); // Unk2
+            // (Only needed for clients TBC+)
+            realmBuffer.Write<u8>(0x10); // Unk1
+            realmBuffer.Write<u8>(0x00); // Unk2
 
-        Common::ByteBuffer RealmListSizeBuffer;
-        RealmListSizeBuffer.Write<u32>(0);
-        RealmListSizeBuffer.Write<u16>(static_cast<u16>(results.affected_rows()));
+            Common::ByteBuffer RealmListSizeBuffer;
+            RealmListSizeBuffer.Write<u32>(0);
+            RealmListSizeBuffer.Write<u16>(static_cast<u16>(results.affected_rows()));
 
-        Common::ByteBuffer hdr;
-        hdr.Write<u8>(AUTH_GAMESERVER_LIST);
+            Common::ByteBuffer hdr;
+            hdr.Write<u8>(AUTH_GAMESERVER_LIST);
 
-        u16 combinedSize = realmBuffer.size() + RealmListSizeBuffer.size();
-        hdr.Write<u16>(combinedSize);
-        hdr.Append(RealmListSizeBuffer);
-        hdr.Append(realmBuffer);
-        Send(hdr);
+            u16 combinedSize = realmBuffer.size() + RealmListSizeBuffer.size();
+            hdr.Write<u16>(combinedSize);
+            hdr.Append(RealmListSizeBuffer);
+            hdr.Append(realmBuffer);
+            Send(hdr);
 
-        _status = STATUS_AUTHED;
-    });
+            _status = STATUS_AUTHED;
+        });
 
     return true;
 }

--- a/projects/authserver/Connections/AuthConnection.h
+++ b/projects/authserver/Connections/AuthConnection.h
@@ -138,6 +138,7 @@ public:
     void HandleCommandChallengeCallback(amy::result_set& results);
 
     bool HandleCommandReconnectChallenge();
+    void HandleCommandReconnectChallengeCallback(amy::result_set& results);
     bool HandleCommandProof();
     bool HandleCommandReconnectProof();
     bool HandleCommandGameServerList();
@@ -145,7 +146,7 @@ public:
     BigNumber N, s, g, v;
     BigNumber b, B;
     BigNumber K;
-    BigNumber _reconnectProof;
+    BigNumber _reconnectSeed;
     AuthStatus _status;
 
     std::string username;

--- a/projects/common/Networking/BaseSocket.h
+++ b/projects/common/Networking/BaseSocket.h
@@ -50,7 +50,7 @@ namespace Common
         {
             if (!dataStore.IsEmpty())
             {
-                _socket->async_write_some(asio::buffer(dataStore.GetInternalData(), dataStore.write),
+                _socket->async_write_some(asio::buffer(dataStore.GetInternalData(), dataStore.WrittenData),
                     std::bind(&BaseSocket::HandleInternalWrite, this, std::placeholders::_1, std::placeholders::_2));
             }
         }

--- a/projects/common/Networking/BaseSocket.h
+++ b/projects/common/Networking/BaseSocket.h
@@ -30,6 +30,7 @@
 #include <asio.hpp>
 #include <asio/placeholders.hpp>
 #include "ByteBuffer.h"
+#include "DataStore.h"
 
 namespace Common
 {
@@ -45,6 +46,14 @@ namespace Common
             return _socket;
         }
 
+        void Send(DataStore& dataStore)
+        {
+            if (!dataStore.IsEmpty())
+            {
+                _socket->async_write_some(asio::buffer(dataStore.GetInternalData(), dataStore.write),
+                    std::bind(&BaseSocket::HandleInternalWrite, this, std::placeholders::_1, std::placeholders::_2));
+            }
+        }
         void Send(ByteBuffer& buffer)
         {
             if (!buffer.empty())

--- a/projects/common/Networking/DataStore.h
+++ b/projects/common/Networking/DataStore.h
@@ -126,7 +126,7 @@ public:
         val = (static_cast<u32>(_data[ReadData]) << 24) | (static_cast<u32>(_data[ReadData + 1]) << 16) | (static_cast<u32>(_data[ReadData + 2]) << 8) | static_cast<u32>(_data[ReadData + 3]);
         ReadData += readSize;
         return true;
-    }    
+    }
     bool GetF32(f32& val)
     {
         assert(_data != nullptr);
@@ -220,7 +220,7 @@ public:
             return false;
 
         _data[WrittenData] = (static_cast<u8>(val >> 8));
-        _data[ReadData + 1] = static_cast<u8>(val);
+        _data[WrittenData + 1] = static_cast<u8>(val);
         WrittenData += writeSize;
         return true;
     }
@@ -233,7 +233,7 @@ public:
             return false;
 
         _data[WrittenData] = (static_cast<u8>(val >> 8));
-        _data[ReadData + 1] = static_cast<u8>(val);
+        _data[WrittenData + 1] = static_cast<u8>(val);
         WrittenData += writeSize;
         return true;
     }
@@ -246,9 +246,9 @@ public:
             return false;
 
         _data[WrittenData] = (static_cast<u8>(val >> 24));
-        _data[ReadData + 1] = (static_cast<u8>(val >> 16));
-        _data[ReadData + 2] = (static_cast<u8>(val >> 8));
-        _data[ReadData + 3] = static_cast<u8>(val);
+        _data[WrittenData + 1] = (static_cast<u8>(val >> 16));
+        _data[WrittenData + 2] = (static_cast<u8>(val >> 8));
+        _data[WrittenData + 3] = static_cast<u8>(val);
         WrittenData += writeSize;
         return true;
     }
@@ -261,9 +261,9 @@ public:
             return false;
 
         _data[WrittenData] = (static_cast<u8>(val >> 24));
-        _data[ReadData + 1] = (static_cast<u8>(val >> 16));
-        _data[ReadData + 2] = (static_cast<u8>(val >> 8));
-        _data[ReadData + 3] = static_cast<u8>(val);
+        _data[WrittenData + 1] = (static_cast<u8>(val >> 16));
+        _data[WrittenData + 2] = (static_cast<u8>(val >> 8));
+        _data[WrittenData + 3] = static_cast<u8>(val);
         WrittenData += writeSize;
         return true;
     }
@@ -276,13 +276,13 @@ public:
             return false;
 
         _data[WrittenData] = static_cast<u8>(val);
-        _data[ReadData + 1] = (static_cast<u8>(val >> 8));
-        _data[ReadData + 2] = (static_cast<u8>(val >> 16));
-        _data[ReadData + 3] = (static_cast<u8>(val >> 24));
-        _data[ReadData + 4] = (static_cast<u8>(val >> 32));
-        _data[ReadData + 5] = (static_cast<u8>(val >> 40));
-        _data[ReadData + 6] = (static_cast<u8>(val >> 48));
-        _data[ReadData + 7] = (static_cast<u8>(val >> 56));
+        _data[WrittenData + 1] = (static_cast<u8>(val >> 8));
+        _data[WrittenData + 2] = (static_cast<u8>(val >> 16));
+        _data[WrittenData + 3] = (static_cast<u8>(val >> 24));
+        _data[WrittenData + 4] = (static_cast<u8>(val >> 32));
+        _data[WrittenData + 5] = (static_cast<u8>(val >> 40));
+        _data[WrittenData + 6] = (static_cast<u8>(val >> 48));
+        _data[WrittenData + 7] = (static_cast<u8>(val >> 56));
         WrittenData += writeSize;
         return true;
     }
@@ -295,13 +295,13 @@ public:
             return false;
 
         _data[WrittenData] = static_cast<u8>(val);
-        _data[ReadData + 1] = (static_cast<u8>(val >> 8));
-        _data[ReadData + 2] = (static_cast<u8>(val >> 16));
-        _data[ReadData + 3] = (static_cast<u8>(val >> 24));
-        _data[ReadData + 4] = (static_cast<u8>(val >> 32));
-        _data[ReadData + 5] = (static_cast<u8>(val >> 40));
-        _data[ReadData + 6] = (static_cast<u8>(val >> 48));
-        _data[ReadData + 7] = (static_cast<u8>(val >> 56));
+        _data[WrittenData + 1] = (static_cast<u8>(val >> 8));
+        _data[WrittenData + 2] = (static_cast<u8>(val >> 16));
+        _data[WrittenData + 3] = (static_cast<u8>(val >> 24));
+        _data[WrittenData + 4] = (static_cast<u8>(val >> 32));
+        _data[WrittenData + 5] = (static_cast<u8>(val >> 40));
+        _data[WrittenData + 6] = (static_cast<u8>(val >> 48));
+        _data[WrittenData + 7] = (static_cast<u8>(val >> 56));
         WrittenData += writeSize;
         return true;
     }

--- a/projects/common/Networking/DataStore.h
+++ b/projects/common/Networking/DataStore.h
@@ -42,13 +42,17 @@ public:
             _data = inData;
         }
 
-        size = inSize;
+        Size = inSize;
     }
-    ~DataStore() { if (_isOwner) { delete[] _data; } }
+    ~DataStore() { if (_isOwner) { delete[] _data; _data = nullptr; } }
 
-    bool CanPerformReadOrWrite(size_t inSize)
+    bool CanPerformRead(size_t inSize)
     {
-        return read + inSize <= size;
+        return ReadData + inSize <= Size;
+    }
+    bool CanPerformWrite(size_t inSize)
+    {
+        return WrittenData + inSize <= Size;
     }
 
     bool GetI8(i8& val)
@@ -56,11 +60,11 @@ public:
         assert(_data != nullptr);
 
         const size_t readSize = sizeof(i8);
-        if (!CanPerformReadOrWrite(readSize))
+        if (!CanPerformRead(readSize))
             return false;
 
-        val = _data[read];
-        read += readSize;
+        val = _data[ReadData];
+        ReadData += readSize;
         return true;
     }
     bool GetU8(u8& val)
@@ -68,11 +72,11 @@ public:
         assert(_data != nullptr);
 
         const size_t readSize = sizeof(u8);
-        if (!CanPerformReadOrWrite(readSize))
+        if (!CanPerformRead(readSize))
             return false;
 
-        val = _data[read];
-        read += readSize;
+        val = _data[ReadData];
+        ReadData += readSize;
         return true;
     }
     bool GetI16(i16& val)
@@ -80,11 +84,11 @@ public:
         assert(_data != nullptr);
 
         const size_t readSize = sizeof(i16);
-        if (!CanPerformReadOrWrite(readSize))
+        if (!CanPerformRead(readSize))
             return false;
 
-        val = (static_cast<u16>(_data[read]) << 8) | static_cast<u16>(_data[read + 1]);
-        read += readSize;
+        val = (static_cast<u16>(_data[ReadData]) << 8) | static_cast<u16>(_data[ReadData + 1]);
+        ReadData += readSize;
         return true;
     }
     bool GetU16(u16& val)
@@ -92,11 +96,11 @@ public:
         assert(_data != nullptr);
 
         const size_t readSize = sizeof(u16);
-        if (!CanPerformReadOrWrite(readSize))
+        if (!CanPerformRead(readSize))
             return false;
 
-        val = (static_cast<u16>(_data[read]) << 8) | static_cast<u16>(_data[read + 1]);
-        read += readSize;
+        val = (static_cast<u16>(_data[ReadData]) << 8) | static_cast<u16>(_data[ReadData + 1]);
+        ReadData += readSize;
         return true;
     }
     bool GetI32(i32& val)
@@ -104,11 +108,11 @@ public:
         assert(_data != nullptr);
 
         const size_t readSize = sizeof(i32);
-        if (!CanPerformReadOrWrite(readSize))
+        if (!CanPerformRead(readSize))
             return false;
 
-        val = (static_cast<u32>(_data[read]) << 24) | (static_cast<u32>(_data[read + 1]) << 16) | (static_cast<u32>(_data[read + 2]) << 8) | static_cast<u32>(_data[read + 3]);
-        read += readSize;
+        val = (static_cast<u32>(_data[ReadData]) << 24) | (static_cast<u32>(_data[ReadData + 1]) << 16) | (static_cast<u32>(_data[ReadData + 2]) << 8) | static_cast<u32>(_data[ReadData + 3]);
+        ReadData += readSize;
         return true;
     }
     bool GetU32(u32& val)
@@ -116,11 +120,11 @@ public:
         assert(_data != nullptr);
 
         const size_t readSize = sizeof(u32);
-        if (!CanPerformReadOrWrite(readSize))
+        if (!CanPerformRead(readSize))
             return false;
 
-        val = (static_cast<u32>(_data[read]) << 24) | (static_cast<u32>(_data[read + 1]) << 16) | (static_cast<u32>(_data[read + 2]) << 8) | static_cast<u32>(_data[read + 3]);
-        read += readSize;
+        val = (static_cast<u32>(_data[ReadData]) << 24) | (static_cast<u32>(_data[ReadData + 1]) << 16) | (static_cast<u32>(_data[ReadData + 2]) << 8) | static_cast<u32>(_data[ReadData + 3]);
+        ReadData += readSize;
         return true;
     }    
     bool GetF32(f32& val)
@@ -128,11 +132,11 @@ public:
         assert(_data != nullptr);
 
         const size_t readSize = sizeof(f32);
-        if (!CanPerformReadOrWrite(readSize))
+        if (!CanPerformRead(readSize))
             return false;
 
-        val = *reinterpret_cast<f32*>(_data[read]);
-        read += readSize;
+        val = *reinterpret_cast<f32*>(_data[ReadData]);
+        ReadData += readSize;
         return true;
     }
     bool GetI64(i64& val)
@@ -140,11 +144,11 @@ public:
         assert(_data != nullptr);
 
         const size_t readSize = sizeof(i64);
-        if (!CanPerformReadOrWrite(readSize))
+        if (!CanPerformRead(readSize))
             return false;
 
-        val = (static_cast<u64>(_data[read]) << 56) | (static_cast<u64>(_data[read + 1]) << 48) | (static_cast<u64>(_data[read + 2]) << 40) | (static_cast<u64>(_data[read + 3]) << 32) | (static_cast<u64>(_data[read + 4]) << 24) | (static_cast<u64>(_data[read + 5]) << 16) | (static_cast<u64>(_data[read + 6]) << 8) | static_cast<u64>(_data[read + 7]);
-        read += readSize;
+        val = (static_cast<u64>(_data[ReadData]) << 56) | (static_cast<u64>(_data[ReadData + 1]) << 48) | (static_cast<u64>(_data[ReadData + 2]) << 40) | (static_cast<u64>(_data[ReadData + 3]) << 32) | (static_cast<u64>(_data[ReadData + 4]) << 24) | (static_cast<u64>(_data[ReadData + 5]) << 16) | (static_cast<u64>(_data[ReadData + 6]) << 8) | static_cast<u64>(_data[ReadData + 7]);
+        ReadData += readSize;
         return true;
     }
     bool GetU64(u64& val)
@@ -152,11 +156,11 @@ public:
         assert(_data != nullptr);
 
         const size_t readSize = sizeof(u64);
-        if (!CanPerformReadOrWrite(readSize))
+        if (!CanPerformRead(readSize))
             return false;
 
-        val = (static_cast<u64>(_data[read]) << 56) | (static_cast<u64>(_data[read + 1]) << 48) | (static_cast<u64>(_data[read + 2]) << 40) | (static_cast<u64>(_data[read + 3]) << 32) | (static_cast<u64>(_data[read + 4]) << 24) | (static_cast<u64>(_data[read + 5]) << 16) | (static_cast<u64>(_data[read + 6]) << 8) | static_cast<u64>(_data[read + 7]);
-        read += readSize;
+        val = (static_cast<u64>(_data[ReadData]) << 56) | (static_cast<u64>(_data[ReadData + 1]) << 48) | (static_cast<u64>(_data[ReadData + 2]) << 40) | (static_cast<u64>(_data[ReadData + 3]) << 32) | (static_cast<u64>(_data[ReadData + 4]) << 24) | (static_cast<u64>(_data[ReadData + 5]) << 16) | (static_cast<u64>(_data[ReadData + 6]) << 8) | static_cast<u64>(_data[ReadData + 7]);
+        ReadData += readSize;
         return true;
     }
     bool GetF64(f64& val)
@@ -164,11 +168,11 @@ public:
         assert(_data != nullptr);
 
         const size_t readSize = sizeof(f64);
-        if (!CanPerformReadOrWrite(readSize))
+        if (!CanPerformRead(readSize))
             return false;
 
-        val = *reinterpret_cast<f64*>(_data[read]);
-        read += readSize;
+        val = *reinterpret_cast<f64*>(_data[ReadData]);
+        ReadData += readSize;
         return true;
     }
 
@@ -177,11 +181,11 @@ public:
         assert(_data != nullptr);
 
         const size_t writeSize = sizeof(i8);
-        if (!CanPerformReadOrWrite(writeSize))
+        if (!CanPerformWrite(writeSize))
             return false;
 
-        _data[write] = val;
-        write += writeSize;
+        _data[WrittenData] = val;
+        WrittenData += writeSize;
         return true;
     }
     bool PutU8(u8 val)
@@ -189,22 +193,22 @@ public:
         assert(_data != nullptr);
 
         const size_t writeSize = sizeof(u8);
-        if (!CanPerformReadOrWrite(writeSize))
+        if (!CanPerformWrite(writeSize))
             return false;
 
-        _data[write] = val;
-        write += writeSize;
+        _data[WrittenData] = val;
+        WrittenData += writeSize;
         return true;
     }
-    bool PutBytes(u8* val, size_t size)
+    bool PutBytes(u8* val, size_t Size)
     {
         assert(_data != nullptr);
 
-        if (!CanPerformReadOrWrite(size))
+        if (!CanPerformWrite(Size))
             return false;
 
-        std::memcpy(&_data[write], val, size);
-        write += size;
+        std::memcpy(&_data[WrittenData], val, Size);
+        WrittenData += Size;
         return true;
     }
     bool PutI16(i16 val)
@@ -212,12 +216,12 @@ public:
         assert(_data != nullptr);
 
         const size_t writeSize = sizeof(i16);
-        if (!CanPerformReadOrWrite(writeSize))
+        if (!CanPerformWrite(writeSize))
             return false;
 
-        _data[write] = (static_cast<u8>(val >> 8));
-        _data[read + 1] = static_cast<u8>(val);
-        write += writeSize;
+        _data[WrittenData] = (static_cast<u8>(val >> 8));
+        _data[ReadData + 1] = static_cast<u8>(val);
+        WrittenData += writeSize;
         return true;
     }
     bool PutU16(u16 val)
@@ -225,12 +229,12 @@ public:
         assert(_data != nullptr);
 
         const size_t writeSize = sizeof(u16);
-        if (!CanPerformReadOrWrite(writeSize))
+        if (!CanPerformWrite(writeSize))
             return false;
 
-        _data[write] = (static_cast<u8>(val >> 8));
-        _data[read + 1] = static_cast<u8>(val);
-        write += writeSize;
+        _data[WrittenData] = (static_cast<u8>(val >> 8));
+        _data[ReadData + 1] = static_cast<u8>(val);
+        WrittenData += writeSize;
         return true;
     }
     bool PutI32(i32 val)
@@ -238,14 +242,14 @@ public:
         assert(_data != nullptr);
 
         const size_t writeSize = sizeof(i32);
-        if (!CanPerformReadOrWrite(writeSize))
+        if (!CanPerformWrite(writeSize))
             return false;
 
-        _data[write] = (static_cast<u8>(val >> 24));
-        _data[read + 1] = (static_cast<u8>(val >> 16));
-        _data[read + 2] = (static_cast<u8>(val >> 8));
-        _data[read + 3] = static_cast<u8>(val);
-        write += writeSize;
+        _data[WrittenData] = (static_cast<u8>(val >> 24));
+        _data[ReadData + 1] = (static_cast<u8>(val >> 16));
+        _data[ReadData + 2] = (static_cast<u8>(val >> 8));
+        _data[ReadData + 3] = static_cast<u8>(val);
+        WrittenData += writeSize;
         return true;
     }
     bool PutU32(u32 val)
@@ -253,14 +257,14 @@ public:
         assert(_data != nullptr);
 
         const size_t writeSize = sizeof(u32);
-        if (!CanPerformReadOrWrite(writeSize))
+        if (!CanPerformWrite(writeSize))
             return false;
 
-        _data[write] = (static_cast<u8>(val >> 24));
-        _data[read + 1] = (static_cast<u8>(val >> 16));
-        _data[read + 2] = (static_cast<u8>(val >> 8));
-        _data[read + 3] = static_cast<u8>(val);
-        write += writeSize;
+        _data[WrittenData] = (static_cast<u8>(val >> 24));
+        _data[ReadData + 1] = (static_cast<u8>(val >> 16));
+        _data[ReadData + 2] = (static_cast<u8>(val >> 8));
+        _data[ReadData + 3] = static_cast<u8>(val);
+        WrittenData += writeSize;
         return true;
     }
     bool PutI64(i64 val)
@@ -268,18 +272,18 @@ public:
         assert(_data != nullptr);
 
         const size_t writeSize = sizeof(i64);
-        if (!CanPerformReadOrWrite(writeSize))
+        if (!CanPerformWrite(writeSize))
             return false;
 
-        _data[write] = static_cast<u8>(val);
-        _data[read + 1] = (static_cast<u8>(val >> 8));
-        _data[read + 2] = (static_cast<u8>(val >> 16));
-        _data[read + 3] = (static_cast<u8>(val >> 24));
-        _data[read + 4] = (static_cast<u8>(val >> 32));
-        _data[read + 5] = (static_cast<u8>(val >> 40));
-        _data[read + 6] = (static_cast<u8>(val >> 48));
-        _data[read + 7] = (static_cast<u8>(val >> 56));
-        write += writeSize;
+        _data[WrittenData] = static_cast<u8>(val);
+        _data[ReadData + 1] = (static_cast<u8>(val >> 8));
+        _data[ReadData + 2] = (static_cast<u8>(val >> 16));
+        _data[ReadData + 3] = (static_cast<u8>(val >> 24));
+        _data[ReadData + 4] = (static_cast<u8>(val >> 32));
+        _data[ReadData + 5] = (static_cast<u8>(val >> 40));
+        _data[ReadData + 6] = (static_cast<u8>(val >> 48));
+        _data[ReadData + 7] = (static_cast<u8>(val >> 56));
+        WrittenData += writeSize;
         return true;
     }
     bool PutU64(u64 val)
@@ -287,26 +291,26 @@ public:
         assert(_data != nullptr);
 
         const size_t writeSize = sizeof(u64);
-        if (!CanPerformReadOrWrite(writeSize))
+        if (!CanPerformWrite(writeSize))
             return false;
 
-        _data[write] = static_cast<u8>(val);
-        _data[read + 1] = (static_cast<u8>(val >> 8));
-        _data[read + 2] = (static_cast<u8>(val >> 16));
-        _data[read + 3] = (static_cast<u8>(val >> 24));
-        _data[read + 4] = (static_cast<u8>(val >> 32));
-        _data[read + 5] = (static_cast<u8>(val >> 40));
-        _data[read + 6] = (static_cast<u8>(val >> 48));
-        _data[read + 7] = (static_cast<u8>(val >> 56));
-        write += writeSize;
+        _data[WrittenData] = static_cast<u8>(val);
+        _data[ReadData + 1] = (static_cast<u8>(val >> 8));
+        _data[ReadData + 2] = (static_cast<u8>(val >> 16));
+        _data[ReadData + 3] = (static_cast<u8>(val >> 24));
+        _data[ReadData + 4] = (static_cast<u8>(val >> 32));
+        _data[ReadData + 5] = (static_cast<u8>(val >> 40));
+        _data[ReadData + 6] = (static_cast<u8>(val >> 48));
+        _data[ReadData + 7] = (static_cast<u8>(val >> 56));
+        WrittenData += writeSize;
         return true;
     }
 
-    bool IsEmpty() { return write == 0; }
+    bool IsEmpty() { return WrittenData == 0; }
 
-    size_t write = 0;
-    size_t read = 0;
-    size_t size = 0;
+    size_t WrittenData = 0;
+    size_t ReadData = 0;
+    size_t Size = 0;
 
     u8* GetInternalData() { return _data; }
 private:

--- a/projects/common/Networking/DataStore.h
+++ b/projects/common/Networking/DataStore.h
@@ -1,0 +1,315 @@
+/*
+# MIT License
+
+# Copyright(c) 2018-2019 NovusCore
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+*/
+#pragma once
+#include "../NovusTypes.h"
+#include <cassert>
+
+class DataStore
+{
+public:
+    DataStore(u8* inData = nullptr, size_t inSize = 128)
+    {
+        assert(inSize > 0);
+
+        if (inData == nullptr)
+        {
+            _data = new u8[inSize];
+            _isOwner = true;
+        }
+        else
+        {
+            _data = inData;
+        }
+
+        size = inSize;
+    }
+    ~DataStore() { if (_isOwner) { delete[] _data; } }
+
+    bool CanPerformReadOrWrite(size_t inSize)
+    {
+        return read + inSize <= size;
+    }
+
+    bool GetI8(i8& val)
+    {
+        assert(_data != nullptr);
+
+        const size_t readSize = sizeof(i8);
+        if (!CanPerformReadOrWrite(readSize))
+            return false;
+
+        val = _data[read];
+        read += readSize;
+        return true;
+    }
+    bool GetU8(u8& val)
+    {
+        assert(_data != nullptr);
+
+        const size_t readSize = sizeof(u8);
+        if (!CanPerformReadOrWrite(readSize))
+            return false;
+
+        val = _data[read];
+        read += readSize;
+        return true;
+    }
+    bool GetI16(i16& val)
+    {
+        assert(_data != nullptr);
+
+        const size_t readSize = sizeof(i16);
+        if (!CanPerformReadOrWrite(readSize))
+            return false;
+
+        val = (static_cast<u16>(_data[read]) << 8) | static_cast<u16>(_data[read + 1]);
+        read += readSize;
+        return true;
+    }
+    bool GetU16(u16& val)
+    {
+        assert(_data != nullptr);
+
+        const size_t readSize = sizeof(u16);
+        if (!CanPerformReadOrWrite(readSize))
+            return false;
+
+        val = (static_cast<u16>(_data[read]) << 8) | static_cast<u16>(_data[read + 1]);
+        read += readSize;
+        return true;
+    }
+    bool GetI32(i32& val)
+    {
+        assert(_data != nullptr);
+
+        const size_t readSize = sizeof(i32);
+        if (!CanPerformReadOrWrite(readSize))
+            return false;
+
+        val = (static_cast<u32>(_data[read]) << 24) | (static_cast<u32>(_data[read + 1]) << 16) | (static_cast<u32>(_data[read + 2]) << 8) | static_cast<u32>(_data[read + 3]);
+        read += readSize;
+        return true;
+    }
+    bool GetU32(u32& val)
+    {
+        assert(_data != nullptr);
+
+        const size_t readSize = sizeof(u32);
+        if (!CanPerformReadOrWrite(readSize))
+            return false;
+
+        val = (static_cast<u32>(_data[read]) << 24) | (static_cast<u32>(_data[read + 1]) << 16) | (static_cast<u32>(_data[read + 2]) << 8) | static_cast<u32>(_data[read + 3]);
+        read += readSize;
+        return true;
+    }    
+    bool GetF32(f32& val)
+    {
+        assert(_data != nullptr);
+
+        const size_t readSize = sizeof(f32);
+        if (!CanPerformReadOrWrite(readSize))
+            return false;
+
+        val = *reinterpret_cast<f32*>(_data[read]);
+        read += readSize;
+        return true;
+    }
+    bool GetI64(i64& val)
+    {
+        assert(_data != nullptr);
+
+        const size_t readSize = sizeof(i64);
+        if (!CanPerformReadOrWrite(readSize))
+            return false;
+
+        val = (static_cast<u64>(_data[read]) << 56) | (static_cast<u64>(_data[read + 1]) << 48) | (static_cast<u64>(_data[read + 2]) << 40) | (static_cast<u64>(_data[read + 3]) << 32) | (static_cast<u64>(_data[read + 4]) << 24) | (static_cast<u64>(_data[read + 5]) << 16) | (static_cast<u64>(_data[read + 6]) << 8) | static_cast<u64>(_data[read + 7]);
+        read += readSize;
+        return true;
+    }
+    bool GetU64(u64& val)
+    {
+        assert(_data != nullptr);
+
+        const size_t readSize = sizeof(u64);
+        if (!CanPerformReadOrWrite(readSize))
+            return false;
+
+        val = (static_cast<u64>(_data[read]) << 56) | (static_cast<u64>(_data[read + 1]) << 48) | (static_cast<u64>(_data[read + 2]) << 40) | (static_cast<u64>(_data[read + 3]) << 32) | (static_cast<u64>(_data[read + 4]) << 24) | (static_cast<u64>(_data[read + 5]) << 16) | (static_cast<u64>(_data[read + 6]) << 8) | static_cast<u64>(_data[read + 7]);
+        read += readSize;
+        return true;
+    }
+    bool GetF64(f64& val)
+    {
+        assert(_data != nullptr);
+
+        const size_t readSize = sizeof(f64);
+        if (!CanPerformReadOrWrite(readSize))
+            return false;
+
+        val = *reinterpret_cast<f64*>(_data[read]);
+        read += readSize;
+        return true;
+    }
+
+    bool PutI8(i8 val)
+    {
+        assert(_data != nullptr);
+
+        const size_t writeSize = sizeof(i8);
+        if (!CanPerformReadOrWrite(writeSize))
+            return false;
+
+        _data[write] = val;
+        write += writeSize;
+        return true;
+    }
+    bool PutU8(u8 val)
+    {
+        assert(_data != nullptr);
+
+        const size_t writeSize = sizeof(u8);
+        if (!CanPerformReadOrWrite(writeSize))
+            return false;
+
+        _data[write] = val;
+        write += writeSize;
+        return true;
+    }
+    bool PutBytes(u8* val, size_t size)
+    {
+        assert(_data != nullptr);
+
+        if (!CanPerformReadOrWrite(size))
+            return false;
+
+        std::memcpy(&_data[write], val, size);
+        write += size;
+        return true;
+    }
+    bool PutI16(i16 val)
+    {
+        assert(_data != nullptr);
+
+        const size_t writeSize = sizeof(i16);
+        if (!CanPerformReadOrWrite(writeSize))
+            return false;
+
+        _data[write] = (static_cast<u8>(val >> 8));
+        _data[read + 1] = static_cast<u8>(val);
+        write += writeSize;
+        return true;
+    }
+    bool PutU16(u16 val)
+    {
+        assert(_data != nullptr);
+
+        const size_t writeSize = sizeof(u16);
+        if (!CanPerformReadOrWrite(writeSize))
+            return false;
+
+        _data[write] = (static_cast<u8>(val >> 8));
+        _data[read + 1] = static_cast<u8>(val);
+        write += writeSize;
+        return true;
+    }
+    bool PutI32(i32 val)
+    {
+        assert(_data != nullptr);
+
+        const size_t writeSize = sizeof(i32);
+        if (!CanPerformReadOrWrite(writeSize))
+            return false;
+
+        _data[write] = (static_cast<u8>(val >> 24));
+        _data[read + 1] = (static_cast<u8>(val >> 16));
+        _data[read + 2] = (static_cast<u8>(val >> 8));
+        _data[read + 3] = static_cast<u8>(val);
+        write += writeSize;
+        return true;
+    }
+    bool PutU32(u32 val)
+    {
+        assert(_data != nullptr);
+
+        const size_t writeSize = sizeof(u32);
+        if (!CanPerformReadOrWrite(writeSize))
+            return false;
+
+        _data[write] = (static_cast<u8>(val >> 24));
+        _data[read + 1] = (static_cast<u8>(val >> 16));
+        _data[read + 2] = (static_cast<u8>(val >> 8));
+        _data[read + 3] = static_cast<u8>(val);
+        write += writeSize;
+        return true;
+    }
+    bool PutI64(i64 val)
+    {
+        assert(_data != nullptr);
+
+        const size_t writeSize = sizeof(i64);
+        if (!CanPerformReadOrWrite(writeSize))
+            return false;
+
+        _data[write] = static_cast<u8>(val);
+        _data[read + 1] = (static_cast<u8>(val >> 8));
+        _data[read + 2] = (static_cast<u8>(val >> 16));
+        _data[read + 3] = (static_cast<u8>(val >> 24));
+        _data[read + 4] = (static_cast<u8>(val >> 32));
+        _data[read + 5] = (static_cast<u8>(val >> 40));
+        _data[read + 6] = (static_cast<u8>(val >> 48));
+        _data[read + 7] = (static_cast<u8>(val >> 56));
+        write += writeSize;
+        return true;
+    }
+    bool PutU64(u64 val)
+    {
+        assert(_data != nullptr);
+
+        const size_t writeSize = sizeof(u64);
+        if (!CanPerformReadOrWrite(writeSize))
+            return false;
+
+        _data[write] = static_cast<u8>(val);
+        _data[read + 1] = (static_cast<u8>(val >> 8));
+        _data[read + 2] = (static_cast<u8>(val >> 16));
+        _data[read + 3] = (static_cast<u8>(val >> 24));
+        _data[read + 4] = (static_cast<u8>(val >> 32));
+        _data[read + 5] = (static_cast<u8>(val >> 40));
+        _data[read + 6] = (static_cast<u8>(val >> 48));
+        _data[read + 7] = (static_cast<u8>(val >> 56));
+        write += writeSize;
+        return true;
+    }
+
+    bool IsEmpty() { return write == 0; }
+
+    size_t write = 0;
+    size_t read = 0;
+    size_t size = 0;
+
+    u8* GetInternalData() { return _data; }
+private:
+    u8* _data;
+    bool _isOwner = false;
+};


### PR DESCRIPTION
The DataStore is a replacement for the ByteBuffer when directly handling of packets.
This PR also implements reconnecting to the authserver after being ingame.